### PR TITLE
added st_make_valid to determine_country_by_coordinates

### DIFF
--- a/R/c14_date_list_spatial_determine_country_by_coordinate.R
+++ b/R/c14_date_list_spatial_determine_country_by_coordinate.R
@@ -73,12 +73,12 @@ get_world_map <- function() {
     stop("Problems loading countriesHigh dataset from package rworldxtra.")
   }
   world <- countriesHigh %>%
-    sf::st_as_sf()
+    sf::st_as_sf() %>% lwgeom::st_make_valid()
   return(world)
 }
 
 spatial_join_with_country_dataset <- function(x) {
-  world <- get_world_map() %>% lwgeom::st_make_valid()
+  world <- get_world_map()
   # transform data to sf
   x_sf <- x %>% sf::st_as_sf(
     coords = c("lon","lat"),

--- a/R/c14_date_list_spatial_determine_country_by_coordinate.R
+++ b/R/c14_date_list_spatial_determine_country_by_coordinate.R
@@ -78,7 +78,7 @@ get_world_map <- function() {
 }
 
 spatial_join_with_country_dataset <- function(x) {
-  world <- get_world_map()
+  world <- get_world_map() %>% lwgeom::st_make_valid()
   # transform data to sf
   x_sf <- x %>% sf::st_as_sf(
     coords = c("lon","lat"),


### PR DESCRIPTION
In some cases (radon), determine_country_by_coordinates results in Evaluation error: TopologyException: Input geom 1 is invalid: Ring Self-intersection at or near point ...

This can be avoided using st_make_valid to fortify the world!