### PR TITLE
added UTF-8 encoding to get_thesaurus fct

### DIFF
--- a/R/helpers_thesauri.R
+++ b/R/helpers_thesauri.R
@@ -53,6 +53,7 @@ get_thesaurus <- function(url) {
       "cor" = "character",
       "var" = "character"
     ),
+    encoding = "UTF-8",
     showProgress = FALSE
   ) %>%
     tibble::as_tibble()


### PR DESCRIPTION
first fix for #96 : `get_thesaurus()` needed UTF-8 encoding specified in order for *España* to be correctly translated to *Spain*

@nevrome merge this and rethink a new way of dealing with differences in (erroneous) coordinated or country names, as discussed in #96 , separately?