### PR TITLE
switch from openxlsx to readxl & writexl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,8 +79,8 @@ Suggests:
     knitr,
     lwgeom,
     mapview,
-    openxlsx,
     plyr,
+    readxl,
     rgeos,
     rmarkdown,
     rnaturalearth,
@@ -88,6 +88,7 @@ Suggests:
     rworldxtra,
     sf,
     stringdist,
-    testthat
+    testthat,
+    writexl
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/R/c14_date_list_write_c14.R
+++ b/R/c14_date_list_write_c14.R
@@ -6,7 +6,7 @@
 #' @param x an object of class c14_date_list
 #' @param format the output format: 'csv' (default) or 'xlsx'.
 #' 'csv' calls \code{utils::write.csv()},
-#' 'xlsx' calls \code{openxlsx::write.xlsx()}
+#' 'xlsx' calls \code{writexl::write_xlsx()}
 #' @param ... passed to the actual writing functions
 #'
 #' @examples
@@ -58,8 +58,8 @@ write_c14.c14_date_list <- function(x, format = c("csv"), ...) {
       utils::write.csv(x, ...)
     },
     xlsx = {
-      check_if_packages_are_available(c("openxlsx"))
-      openxlsx::write.xlsx(x, ...)
+      check_if_packages_are_available(c("writexl"))
+      writexl::write_xlsx(x, ...)
     }
   )
 

--- a/R/c14_date_list_write_c14.R
+++ b/R/c14_date_list_write_c14.R
@@ -10,11 +10,20 @@
 #' @param ... passed to the actual writing functions
 #'
 #' @examples
+#' csv_file <- tempfile(fileext = ".csv")
 #' write_c14(
 #'   example_c14_date_list,
-#'   file = tempfile(),
-#'   format = "csv"
+#'   format = "csv",
+#'   file = csv_file
 #' )
+#' \donttest{
+#' xlsx_file <- tempfile(fileext = ".xlsx")
+#' write_c14(
+#'   example_c14_date_list,
+#'   format = "xlsx",
+#'   path = xlsx_file,
+#' )
+#' }
 #'
 #' @export
 #'

--- a/R/get_14cpalaeolithic.R
+++ b/R/get_14cpalaeolithic.R
@@ -11,9 +11,8 @@ get_14cpalaeolithic <- function(db_url = get_db_url("14cpalaeolithic")) {
   utils::download.file(url = db_url, destfile = temp, mode = "wb", quiet = TRUE)
 
   # read data
-  db_raw <- openxlsx::read.xlsx(
-    temp,
-    sheet = 1
+  db_raw <- readxl::read_excel(
+    temp, sheet = 1
   ) %>%
     dplyr::mutate_if(
       sapply(., is.character),
@@ -30,9 +29,9 @@ get_14cpalaeolithic <- function(db_url = get_db_url("14cpalaeolithic")) {
       method = .data[["method"]],
       labnr = .data[["labref"]],
       c14age = .data[["age"]],
-      c14std = .data[["sigma.+/-"]],
+      c14std = .data[["sigma +/-"]],
       site = .data[["sitename"]],
-      period = .data[["cult.stage"]],
+      period = .data[["cult stage"]],
       material = .data[["sample"]],
       country = .data[["country"]],
       lat = .data[["coord_lat"]],

--- a/R/get_14sea.R
+++ b/R/get_14sea.R
@@ -3,7 +3,7 @@
 #' @export
 get_14sea <- function(db_url = get_db_url("14sea")) {
 
-  check_if_packages_are_available("openxlsx")
+  check_if_packages_are_available("readxl")
 
   check_connection_to_url(db_url)
 
@@ -13,11 +13,8 @@ get_14sea <- function(db_url = get_db_url("14sea")) {
 
   # read data
   SEA14 <- tempo %>%
-    openxlsx::read.xlsx(
-      na.strings = c("Combination fails", "nd", "-"),
-      startRow = 2,
-      colNames = FALSE,
-      rowNames = FALSE
+    readxl::read_excel(
+      na = c("Combination fails", "nd", "-"),
     ) %>%
     dplyr::mutate_if(
       sapply(., is.character),
@@ -31,7 +28,7 @@ get_14sea <- function(db_url = get_db_url("14sea")) {
       material = .[[11]],
       country = .[[4]],
       region = .[[2]],
-      site = .[[1]],
+      site = .[["Site"]],
       lat = NA,
       lon = NA,
       period = .[[15]],

--- a/R/get_eubar.R
+++ b/R/get_eubar.R
@@ -2,7 +2,7 @@
 #' @export
 get_eubar <- function(db_url = get_db_url("eubar")) {
 
-  check_if_packages_are_available("openxlsx")
+  check_if_packages_are_available("readxl")
 
   check_connection_to_url(db_url)
 
@@ -12,11 +12,8 @@ get_eubar <- function(db_url = get_db_url("eubar")) {
 
   # read data
   eubar <- tempo %>%
-    openxlsx::read.xlsx(
-      na.strings = c("Combination fails", "nd", "-"),
-      startRow = 2,
-      colNames = FALSE,
-      rowNames = FALSE
+    readxl::read_excel(
+      na = c("Combination fails", "nd", "-"),
     ) %>%
     dplyr::mutate_if(
       sapply(., is.character),

--- a/R/get_irdd.R
+++ b/R/get_irdd.R
@@ -2,7 +2,7 @@
 #' @export
 get_irdd <- function(db_url = get_db_url("irdd")) {
 
-  check_if_packages_are_available("openxlsx")
+  check_if_packages_are_available("readxl")
 
   check_connection_to_url(db_url)
 
@@ -12,12 +12,11 @@ get_irdd <- function(db_url = get_db_url("irdd")) {
 
   # read data
   irdd <- tempo %>%
-    openxlsx::read.xlsx(
+    readxl::read_excel(
       sheet = 3,
-      startRow = 2,
-      colNames = FALSE,
-      rowNames = FALSE,
-      na.strings = c("?")
+      na = c("?"),
+      skip = 1,
+      col_names =  FALSE
     ) %>%
     dplyr::mutate_if(
       sapply(., is.character),

--- a/man/write_c14.Rd
+++ b/man/write_c14.Rd
@@ -17,7 +17,7 @@ write_c14(x, format = c("csv"), ...)
 
 \item{format}{the output format: 'csv' (default) or 'xlsx'.
 'csv' calls \code{utils::write.csv()},
-'xlsx' calls \code{openxlsx::write.xlsx()}}
+'xlsx' calls \code{writexl::write_xlsx()}}
 
 \item{...}{passed to the actual writing functions}
 }

--- a/man/write_c14.Rd
+++ b/man/write_c14.Rd
@@ -25,10 +25,19 @@ write_c14(x, format = c("csv"), ...)
 write \strong{c14_date_list}s to files
 }
 \examples{
+csv_file <- tempfile(fileext = ".csv")
 write_c14(
   example_c14_date_list,
-  file = tempfile(),
-  format = "csv"
+  format = "csv",
+  file = csv_file
 )
+\donttest{
+xlsx_file <- tempfile(fileext = ".xlsx")
+write_c14(
+  example_c14_date_list,
+  format = "xlsx",
+  path = xlsx_file,
+)
+}
 
 }

--- a/tests/testthat/test_c14_date_list_write_c14.R
+++ b/tests/testthat/test_c14_date_list_write_c14.R
@@ -21,7 +21,7 @@ test_that("list columns are correctly recognized and a message created", {
 })
 
 csv_read <- read.csv(csv_file, stringsAsFactors = F, row.names = 1)
-xlsx_read <- openxlsx::read.xlsx(xlsx_file)
+xlsx_read <- readxl::read_excel(xlsx_file)
 
 test_that("written files are generally fine", {
   # result dimensions

--- a/tests/testthat/test_c14_date_list_write_c14.R
+++ b/tests/testthat/test_c14_date_list_write_c14.R
@@ -9,7 +9,7 @@ test_that("writing to file works without errors", {
     write_c14(example_c14_date_list, file = csv_file, format = "csv")
   )
   expect_silent(
-    write_c14(example_c14_date_list, file = xlsx_file, format = "xlsx")
+    write_c14(example_c14_date_list, path = xlsx_file, format = "xlsx")
   )
 })
 


### PR DESCRIPTION
Updated parsers that rely on xlsx input data (`get_14cpalaeolithic()`, `get_14sea()`, `get_eubar()`, `get_irdd()`). Removed `openxlsx::read.xlsx()` with `readxl::read_excel()`.

One question: how is codemeta.json generated; manually or automatically? There openxlsx is still listed.

Had issue with the write `write_c14(. , format = "xlsx")` and tests failed on that stage.

@nevrome can you test and verify that the parsers work?