### PR TITLE
filter out TL dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: c14bazAAR
 Title: Download and Prepare C14 Dates from Different Source Databases
 Description: Query different C14 date databases and apply basic data cleaning, merging and calibration steps. Currently available databases: 14cpalaeolithic, 14sea, adrac, austarch, calpal, context, emedyd, eubar, euroevol, irdd, jomon, katsianis, kiteeastafrica, medafricarbon, mesorad, pacea, palmisano, radon, radonb.
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: 
     c(person(given = "Clemens",
              family = "Schmid",

--- a/R/get_adrac.R
+++ b/R/get_adrac.R
@@ -49,7 +49,11 @@ get_adrac <- function(db_url = get_db_url("adrac")) {
       lon = .data[["LONG"]],
       comment = .data[["REMARK"]],
       shortref = .data[["SOURCE"]]
-    ) %>% dplyr::mutate(
+    ) %>%
+    dplyr::filter(
+      is.na(method) | method != "TL"
+    ) %>%
+    dplyr::mutate(
       sourcedb = "adrac",
       sourcedb_version = get_db_version("adrac")
     ) %>%

--- a/R/get_adrac.R
+++ b/R/get_adrac.R
@@ -51,7 +51,7 @@ get_adrac <- function(db_url = get_db_url("adrac")) {
       shortref = .data[["SOURCE"]]
     ) %>%
     dplyr::filter(
-      is.na(method) | method != "TL"
+      is.na(.data[["method"]]) | .data[["method"]] != "TL"
     ) %>%
     dplyr::mutate(
       sourcedb = "adrac",


### PR DESCRIPTION
As aDRAC still contains some TL dates, those are not to be delivered through the c14bazAAR, thus the parser needs to filter those out.

@nevrome : when running the checks, I get the following note:
```
N  checking R code for possible problems (5.9s)
   get_adrac: no visible binding for global variable 'method'
   Undefined global functions or variables:
     method
```
I tried different ways to filter out the TL entries, while keeping the NA entries. If you have an idea, I'd be happy.