### PR TITLE
Added previous items from CRAN checklist to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Before submitting patches or new getter functions via a pull request, we ask you
 
 Please make sure to run the tests listed above and pay special attention to the highlighted items.
 
+#### Versioning
+
+Version numbers (releases) follow the [semantic versioning schema](https://semver.org/) and consits of mayor and minor releases as well as patches.
+
+* **x**.y.z: a **mayor** release will be made once an existing funciton of removed and thus the API is changed.
+* x.**y**.z: a **minor** release contains new parsers and auxiliary funcitons.
+* x.y.**z**: a **patch** updates existing parsers and functions.
+
 ### Citation
 
 Schmid et al., (2019). c14bazAAR: An R package for downloading and preparing C14 dates from different source databases. Journal of Open Source Software, 4(43), 1914, https://doi.org/10.21105/joss.01914

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ c14bazAAR is an R package to query different openly accessible radiocarbon date 
 - [**Installation**](#installation)
 - [**How to use**](#how-to-use) ([Download](#download), [Calibration](#calibration), [Material classification](#material-classification), [Country attribution](#country-attribution), [Duplicates](#duplicates), [Conversion](#conversion), [Technical functions](#technical-functions), [Plotting and visualization](#plotting-radiocarbon-data), [Interaction with other radiocarbon data packages](#other-radiocarbon-packages))
 - [**Databases**](#databases)
-- [**Contributing**](#contributing) ([Adding database getter functions](#adding-database-getter-functions))
+- [**Contributing**](#contributing) ([Adding database getter functions](#adding-database-getter-functions), [Pre-submision testing](#pre-submision-testing), [Versioning](#versioning))
 - [**Citation**](#citation)
 - [**License**](#license)
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ If you want to use data downloaded with c14bazAAR for your research, you have to
 
 ### Installation
 
-We recommend to install the development version from github with the following command (in your R console):
+We recommend to install the stable version from the [R-universe](https://r-universe.dev/) repository of [rOpenSci](https://ropensci.org/) with the following command (in your R console):
+
+```
+install.packages("c14bazAAR", repos = c(ropensci = "https://ropensci.r-universe.dev"))
+```
+
+The development version can be installed from github with the following command (in your R console):
 
 ```
 if(!require('remotes')) install.packages('remotes')
 remotes::install_github("ropensci/c14bazAAR")
 ```
 
-It is up-to-date and includes more databases and features compared to the CRAN version, though it might be a little bit more unstable. Installing the development version on Windows requires the toolchain bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/).
-
-An older, stable version of c14bazAAR is on [CRAN](https://cran.r-project.org/) and you can install it with:
-
-```
-install.packages("c14bazAAR")
-```
+Both versions are up-to-date and include all databases and features. Installing the development version on Windows requires the toolchain bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/).
 
 The package needs a lot of other packages -- many of them only necessary for specific tasks. Functions that require certain packages you don't have installed yet will stop and ask you to enable them. Please do so with [`install.packages()`](https://www.r-bloggers.com/installing-r-packages/) to download and install the respective packages from CRAN.
 
@@ -207,6 +207,28 @@ If you want to add another radiocarbon database to c14bazAAR (maybe from the lis
 9. Document the addition of the new function in the NEWS.md file.
 10. Add the new database to the list of *Currently available databases* in the DESCRIPTION file.
 11. Add your function to the database list in the README file [here](https://github.com/ropensci/c14bazAAR#databases).
+
+#### Pre-submision testing
+
+Before submitting patches or new getter functions via a pull request, we ask you to check the following items:
+
+1. The package works and all functions are usable
+2. The package documentation is up-to-date and represents the functions correctly
+3. The test coverage of the package functions is sufficient
+4. `DESCRIPTION` is up-to-date with the latest version number and database list
+5. `README.md` is up-to-date
+6. `NEWS.md` is up-to-date and includes the latest changes
+7. **Package checks ran and did not yield any ERRORS, WARNINGS or NOTES (or at least the NOTES are addressed in the cran-comments.md)**
+	- **locally (`devtools::check()`)**
+	- rhub (`devtools::check_rhub(email = ...)`)
+	- winbuilder (`devtools::check_win_release(email = ....)` + `devtools::check_win_devel(email = ....)`)
+8. Spellcheck with `devtools::spell_check()` ran and did yield not only false-positives
+9. codemeta.json is up-to-date (can be updated with `codemetar::write_codemeta()`)
+10. `inst/CITATION` is up-to-date
+11. The package does not make external changes without explicit user permission. It does not write to the file system, change options, install packages, quit R, send information over the internet, open external software, etc.
+12. No reverse dependencies break because of the new package version (`devtools::revdep_check()`)
+
+Please make sure to run the tests listed above and pay special attention to the highlighted items.
 
 ### Citation
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ Please make sure to run the tests listed above and pay special attention to the 
 
 #### Versioning
 
-Version numbers (releases) follow the [semantic versioning schema](https://semver.org/) and consits of mayor and minor releases as well as patches.
+Version numbers (releases) follow the [semantic versioning schema](https://semver.org/) and consist of mayor and minor releases as well as patches.
 
-* **x**.y.z: a **mayor** release will be made once an existing funciton of removed and thus the API is changed.
-* x.**y**.z: a **minor** release contains new parsers and auxiliary funcitons.
+* **x**.y.z: a **mayor** release will be made once an existing function is radically changed or removed and thus the package API is changed.
+* x.**y**.z: a **minor** release contains new parsers and auxiliary functions.
 * x.y.**z**: a **patch** updates existing parsers and functions.
 
 ### Citation


### PR DESCRIPTION
With not focusing on future CRAN releases, the notes from #116 can be moved over to the README to guide other contributors. Furthermore our decision on following semantic versioning is documented in the README.

@nevrome are you okay with these changes? 