### PR TITLE
Dev mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# c14bazAAR 1.3.2
+
+- added submission ToDo list to README (#124)
+- defined version update schema in README (#124)
+
+# c14bazAAR 1.3.1
+
+- filtered out TL dates from aDRAC in parser function (#123)
+
 # c14bazAAR 1.3.0
 
 ## general changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# c14bazAAR 1.3.3
+
+- added a dev mode according to (#122)
+
 # c14bazAAR 1.3.2
 
 - added submission ToDo list to README (#124)

--- a/R/helpers_dbs.R
+++ b/R/helpers_dbs.R
@@ -59,7 +59,12 @@ get_db_info <- function(
     "url_reference.csv"
   ), collapse = "/")) {
 
-  check_connection_to_url(ref_url)
+  # check if dev_mode is turned on and only local data is used
+  if (isTRUE(getOption("c14bazAAR_dev_mode"))) {
+    ref_url <- "data-raw/url_reference.csv"
+  } else {
+    check_connection_to_url(ref_url)
+  }
 
   if (length(db_name) > 1) {
     stop("get_db_info only works for one database at a time")

--- a/R/helpers_thesauri.R
+++ b/R/helpers_thesauri.R
@@ -14,6 +14,12 @@ get_country_thesaurus <- function(
     "data-raw",
     "country_thesaurus.csv"
   ), collapse = "/")) {
+  # check if dev_mode is turned on and only local data is used
+  if (isTRUE(getOption("c14bazAAR_dev_mode"))) {
+    ref_url <- "data-raw/country_thesaurus.csv"
+  } else {
+    check_connection_to_url(ref_url)
+  }
   ref_url %>% get_thesaurus() %>% return()
 }
 
@@ -33,7 +39,13 @@ get_material_thesaurus <- function(
     "data-raw",
     "material_thesaurus.csv"
   ), collapse = "/")) {
-    ref_url %>% get_thesaurus() %>% return()
+  # check if dev_mode is turned on and only local data is used
+  if (isTRUE(getOption("c14bazAAR_dev_mode"))) {
+    ref_url <- "data-raw/material_thesaurus.csv"
+  } else {
+    check_connection_to_url(ref_url)
+  }
+  ref_url %>% get_thesaurus() %>% return()
   }
 
 #' get_thesaurus

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ To suggest other archives to be queried you can join the discussion [here](https
 
 If you would like to contribute to this project, please start by reading our [Guide to Contributing](https://github.com/ropensci/c14bazAAR/blob/master/CONTRIBUTING.md). Please note that this project is released with a Contributor [Code of Conduct](https://github.com/ropensci/c14bazAAR/blob/master/CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+#### Developer mode
+
+The lookup table files for database URLs, as well as country and material thesauri, are always downloaded from the `data_raw` directory on the master branch on Github. This makes is somewhat cumbersome to test changes to the respective files. With `options(c14bazAAR_dev_mode = TRUE)` a developer mode can be activated that does instead use the local versions of the files. Unfortunately this mode does not cover the test and check environments.
+
 #### Adding database getter functions
 
 If you want to add another radiocarbon database to c14bazAAR (maybe from the list [here](https://github.com/ropensci/c14bazAAR/issues/2)) you can follow this checklist to apply all the necessary changes to the package:


### PR DESCRIPTION
Here is a draft for a solution to #122. Unfortunately running the tests and checks both locally and on travis/github actions is not covered with this solution. This is actually rather tricky and I had no clever idea how to do this so far. 

Most likely it will require a larger change to the way we store the lookup tables. Actually we could think about this now. The current position in `data_raw` was a derived effect of the few CRAN releases we could do. With the new deployment system via the universe, we could rethink that. We could put the data back into the shipped package. That would render this PR obsolete.

